### PR TITLE
prevents app crash - guards against removing char from an empty code

### DIFF
--- a/Project/PrivateVault App/Code/UI/LockView/LockView.swift
+++ b/Project/PrivateVault App/Code/UI/LockView/LockView.swift
@@ -41,6 +41,9 @@ struct LockView: View {
 	}
 	
 	func delete() {
+		guard !code.isEmpty else {
+			return
+		}
 		code.removeLast()
 		isIncorrect = false
 	}


### PR DESCRIPTION
Problem:
When the user presses the delete button against an empty code in the Lock screen, the delete function tries to delete the last char from an empty code string and app crashes

Solution:
guard against an empty code at the start of the delete function